### PR TITLE
fixed the open timers problem

### DIFF
--- a/graphdat.c
+++ b/graphdat.c
@@ -205,8 +205,8 @@ PHP_MSHUTDOWN_FUNCTION(graphdat)
 PHP_RINIT_FUNCTION(graphdat)
 {
     gettimeofday(&GRAPHDAT_GLOBALS(requestStart), NULL);
-    initTimerList(8, &GRAPHDAT_GLOBALS(timers));
     freeTimerList(&GRAPHDAT_GLOBALS(timers));
+    initTimerList(8, &GRAPHDAT_GLOBALS(timers));
     beginTimer(&GRAPHDAT_GLOBALS(timers), "", GRAPHDAT_GLOBALS(requestStart));
     return SUCCESS;
 }

--- a/src/timers.c
+++ b/src/timers.c
@@ -136,8 +136,16 @@ void endTimer(struct graphdat_timer_list* timerList, char *name)
     }
     if(strcmp(timerList->array[timerList->currentIndex].name, name) != 0)
     {
-        zend_error(E_ERROR, "Could not end timer named '%s' since it's not the last timer to begin.", name);
-        return;
+        if (strcmp(name, "") != 0)
+        {
+        	zend_error(E_ERROR, "Could not end timer named '%s' since it's not the last timer to begin.", name);
+        	return;
+        }
+
+        while(strcmp(timerList->array[timerList->currentIndex].name, name) != 0)
+        {
+        	endTimer(timerList, timerList->array[timerList->currentIndex].name);
+        }
     }
     struct timeval timeNow;
     struct graphdat_timer *timer = (struct graphdat_timer*) &timerList->array[timerList->currentIndex];


### PR DESCRIPTION
moved the freeTimerList-function before initTimerList in PHP_RINIT_FUNCTION
end all (accidentally) open timers when the main-timer ("") is ended
